### PR TITLE
security: stricter pnpm config blockExoticSubdeps & trustPolicy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 cleanupUnusedCatalogs: true
 linkWorkspacePackages: true
 preferWorkspacePackages: true
+blockExoticSubdeps: true
+trustPolicy: 'no-downgrade'
 
 packages:
   - 'examples/**/*'


### PR DESCRIPTION
Enables pnpm's no-downgrade trust policy and blocks exotic transitive dependencies via blockExoticSubdeps.